### PR TITLE
Keep heroku node modules

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,5 +4,5 @@
 BUILD_DIR=$1
 
 echo "-----> Deleting node_modules directories"
-rm -rf $BUILD_DIR/node_modules
-rm -rf $BUILD_DIR/ui/node_modules 
+rm -rf "$BUILD_DIR/node_modules"
+rm -rf "$BUILD_DIR/ui/node_modules" 

--- a/bin/compile
+++ b/bin/compile
@@ -3,5 +3,6 @@
 
 BUILD_DIR=$1
 
-echo "-----> Deleting the node_modules directory"
-find $BUILD_DIR -name 'node_modules' -type d -prune -print -exec rm -rf '{}' \;
+echo "-----> Deleting node_modules directories"
+rm -rf $BUILD_DIR/node_modules
+rm -rf $BUILD_DIR/ui/node_modules 


### PR DESCRIPTION
Keep the heroku cli node_modules (we need it) but delete the SPA and legacy react folders as they are too large for our slug size limits.